### PR TITLE
Add method for saving converted list to a file

### DIFF
--- a/src/toolbox/output_operations.py
+++ b/src/toolbox/output_operations.py
@@ -1,0 +1,11 @@
+# Output the converted list (any string list) to the file path described
+def output_flextext(file_path, converted_list):
+    try:
+        with open(file_path, "w") as flextext_file:
+            flextext_file.write("\n".join(converted_list))
+
+    except FileNotFoundError:
+        raise
+
+    except PermissionError:
+        raise

--- a/tests/test_output_operations.py
+++ b/tests/test_output_operations.py
@@ -1,0 +1,115 @@
+import os
+import stat
+
+import pytest
+
+from toolbox.output_operations import output_flextext
+
+simple_sample_list = [
+    "This is a simple list of strings",
+    "These strings are in simple in nature",
+    "These strings are offended by your belittling of them",
+    "So you found me. Congratulations. Was it worth it?",
+]
+
+# Duplicate of a version of Freeform.flextext
+freeform_copy = """<?xml version="1.0" encoding="utf-8"?>
+<document version="2">
+  <interlinear-text guid="e763856d-1baa-4f4e-9e2e-1417d56709af">
+    <item type="title" lang="ext">Freeform</item>
+    <paragraphs>
+      <paragraph guid="e3cb6669-59c6-4af4-9c1d-0903bbb742ea">
+        <phrases>
+          <phrase guid="b54f36e5-b75b-4cc2-b9e9-893857d62cfc">
+            <item type="txt" lang="ext">This has a translation.</item>
+            <item type="segnum" lang="en">1</item>
+            <words>
+              <word guid="e91a7bd6-a79a-4d2c-9e70-2659fc183065">
+                <item type="txt" lang="ext">This</item>
+                <morphemes>
+                  <morph>
+                    <item type="txt" lang="ext">this</item>
+                  </morph>
+                </morphemes>
+                <item type="gls" lang="en">this</item>
+              </word>
+              <word guid="c9f72821-7fa5-4132-97bb-f461936273de">
+                <item type="txt" lang="ext">has</item>
+              </word>
+              <word guid="535b6edb-9f96-4cde-b430-4501808cb277">
+                <item type="txt" lang="ext">a</item>
+              </word>
+              <word guid="fbf7a9f7-3818-44de-b326-8adcdde10b5e">
+                <item type="txt" lang="ext">translation</item>
+              </word>
+              <word>
+                <item type="punct" lang="ext">.</item>
+              </word>
+            </words>
+            <item type="gls" lang="en">It is a freeform translation.</item>
+            <item type="lit" lang="en"></item>
+          </phrase>
+        </phrases>
+      </paragraph>
+    </paragraphs>
+    <languages>
+      <language lang="ext" font="Charis SIL" vernacular="true" />
+      <language lang="en" font="Times New Roman" />
+    </languages>
+  </interlinear-text>
+</document>
+"""
+complex_sample_list = [line.replace("\n", "") for line in freeform_copy.splitlines()]
+
+
+# Tests that files are created
+def test_file_creation():
+    output_path = "./tests/output_test_files/test_file_creation.flextext"
+    output_flextext(output_path, simple_sample_list)
+    assert os.path.isfile(output_path) is True
+
+
+# Test that output in file matches input with a simple string list
+def test_file_contents_simple():
+    out_path = "./tests/output_test_files/test_file_contents_simple.flextext"
+    output_flextext(out_path, simple_sample_list)
+
+    with open(out_path, "r") as file:
+        file_contents = [line.replace("\n", "") for line in file.readlines()]
+
+    assert (file_contents == simple_sample_list) is True
+
+
+# Test that output in file matches input with a complex & realistic string list
+def test_file_contents_complex():
+    out_path = "./tests/output_test_files/test_file_contents_complex.flextext"
+    output_flextext(out_path, complex_sample_list)
+
+    with open(out_path, "r") as file:
+        file_contents = [line.replace("\n", "") for line in file.readlines()]
+
+    assert (file_contents == complex_sample_list) is True
+
+
+# Test that an exception is thrown when an invalid path is provided
+def test_invalid_file_path():
+    with pytest.raises(FileNotFoundError):
+        output_flextext("./tests/fake_folder/fake_file.flextext", simple_sample_list)
+
+
+# Test that an exception is thrown when the file is un-writeable
+def test_no_write_perms():
+    # Create the file first
+    out_path = "./tests/output_test_files/test_no_write_perms.flextext"
+    with open(out_path, "w") as f:
+        f.write("This file shouldn't have been modified.")
+
+    # Change its permissions to be read-only
+    os.chmod(out_path, stat.S_IREAD)
+
+    # Now run the function that should raise a PermissionError
+    with pytest.raises(PermissionError):
+        output_flextext(out_path, simple_sample_list)
+
+    # Change its permissions to allow writing so future tests don't fail
+    os.chmod(out_path, stat.S_IWRITE)


### PR DESCRIPTION
Add a `output_flextext` method to take a string list and output to a file path, maintaining whitespace and newlines
Add 5 tests to test the `output_flextext` method