### PR TITLE
feature/json_operations

### DIFF
--- a/src/toolbox/json_marker_files/test_json_contents_complex.json
+++ b/src/toolbox/json_marker_files/test_json_contents_complex.json
@@ -1,0 +1,1 @@
+{"\\ref": {"\\nam": "Reference Number", "\\lng": "Default", "\\fnt": {"\\Name": "Times New Roman", "\\Size": "10", "\\charset": "00", "\\rgbColor": "128,128,128"}, "\\mkrOverThis": "name"}}

--- a/src/toolbox/json_marker_files/test_json_contents_simple.json
+++ b/src/toolbox/json_marker_files/test_json_contents_simple.json
@@ -1,0 +1,1 @@
+{"\\dt": {"\\nam": "*", "\\lng": "Default", "\\mkrOverThis": "name"}}

--- a/src/toolbox/json_marker_files/test_json_creation.json
+++ b/src/toolbox/json_marker_files/test_json_creation.json
@@ -1,0 +1,1 @@
+{"\\dt": {"\\nam": "*", "\\lng": "Default", "\\mkrOverThis": "name"}}

--- a/src/toolbox/json_operations.py
+++ b/src/toolbox/json_operations.py
@@ -1,0 +1,14 @@
+import json
+
+
+def save_map_to_json(marker_map, name):
+    filename = f"./src/toolbox/json_marker_files/{name}.json"
+    with open(filename, "w") as f:
+        json.dump(marker_map, f)
+
+
+def load_map_from_json(name):
+    filename = f"./src/toolbox/json_marker_files/{name}.json"
+    with open(filename, "r") as f:
+        marker_map: object = json.load(f)
+    return marker_map

--- a/tests/test_json_operations.py
+++ b/tests/test_json_operations.py
@@ -1,7 +1,6 @@
 import os
 
-from toolbox.json_operations import save_map_to_json
-from toolbox.json_operations import load_map_from_json
+from toolbox.json_operations import load_map_from_json, save_map_to_json
 
 # Duplicated from test_marker_operations
 # test_map1
@@ -31,13 +30,10 @@ def test_json_creation():
 
 
 def test_json_contents_simple():
-    output_path = "./src/toolbox/json_marker_files/test_json_contents_simple.json"
     save_map_to_json(test_map1, "test_json_contents_simple")
     assert (test_map1 == load_map_from_json("test_json_contents_simple")) is True
 
 
 def test_json_contents_complex():
-    output_path = "./src/toolbox/json_marker_files/test_json_contents_complex.json"
     save_map_to_json(test_map2, "test_json_contents_complex")
     assert (test_map2 == load_map_from_json("test_json_contents_complex")) is True
-

--- a/tests/test_json_operations.py
+++ b/tests/test_json_operations.py
@@ -1,0 +1,43 @@
+import os
+
+from toolbox.json_operations import save_map_to_json
+from toolbox.json_operations import load_map_from_json
+
+# Duplicated from test_marker_operations
+# test_map1
+sub_test_map1 = {"\\nam": "*", "\\lng": "Default", "\\mkrOverThis": "name"}
+test_map1 = {"\\dt": sub_test_map1}
+
+# test_map2
+font_sub_test_map2 = {
+    "\\Name": "Times New Roman",
+    "\\Size": "10",
+    "\\charset": "00",
+    "\\rgbColor": "128,128,128",
+}
+sub_test_map2 = {
+    "\\nam": "Reference Number",
+    "\\lng": "Default",
+    "\\fnt": font_sub_test_map2,
+    "\\mkrOverThis": "name",
+}
+test_map2 = {"\\ref": sub_test_map2}
+
+
+def test_json_creation():
+    output_path = "./src/toolbox/json_marker_files/test_json_creation.json"
+    save_map_to_json(test_map1, "test_json_creation")
+    assert os.path.isfile(output_path) is True
+
+
+def test_json_contents_simple():
+    output_path = "./src/toolbox/json_marker_files/test_json_contents_simple.json"
+    save_map_to_json(test_map1, "test_json_contents_simple")
+    assert (test_map1 == load_map_from_json("test_json_contents_simple")) is True
+
+
+def test_json_contents_complex():
+    output_path = "./src/toolbox/json_marker_files/test_json_contents_complex.json"
+    save_map_to_json(test_map2, "test_json_contents_complex")
+    assert (test_map2 == load_map_from_json("test_json_contents_complex")) is True
+


### PR DESCRIPTION
Add `save_map_to_json` and `load_map_from_json` methods to save and load marker maps with JSON files
Add tests for `save_map_to_json` and `load_map_from_json`